### PR TITLE
DKG votes, sigs, knowledge and AE ground work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,10 @@ license = "MIT"
 [dependencies]
 bincode = "1.2.0"
 byteorder = "1.3.2"
-failure = "0.1.6"
 hex_fmt = "0.3"
 rand = "0.6.5"
 serde = { version = "1.0.102", features = ["derive", "rc"] }
 tiny-keccak = { version = "2.0.1", features = ["sha3"]}
+thiserror = "1.0.31"
 bls = { package = "blsttc", version = "6.0.0" }
+log = "0.4.13"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use crate::sdkg::Error as DkgError;
+use thiserror::Error;
+
+/// All the Dkg Errors
+#[derive(Error, Debug)]
+pub enum Error {
+    /// SDKG faults and errors
+    #[error("Dkg Error")]
+    Sdkg(#[from] DkgError),
+    /// Encoding
+    #[error("Failed to encode with bincode")]
+    Encoding(#[from] bincode::Error),
+    /// Invalid DkgState init input parameters
+    #[error("Failed to initialize DkgState: secret key is not in provided pub key set")]
+    NotInPubKeySet,
+    /// Invalid signature
+    #[error("Invalid signature")]
+    InvalidSignature,
+    /// Got vote from an unknown sender id
+    #[error("Unknown sender")]
+    UnknownSender,
+    /// Got a faulty vote, some nodes are dishonest or dysfunctional
+    #[error("Faulty vote {0}")]
+    FaultyVote(String),
+    /// Unexpectedly failed to generate secret key share
+    #[error("Unexpectedly failed to generate secret key share")]
+    FailedToGenerateSecretKeyShare,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/knowledge.rs
+++ b/src/knowledge.rs
@@ -1,0 +1,96 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use log::debug;
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+use crate::vote::{DkgVote, IdAck, IdPart, NodeId};
+
+pub(crate) struct Knowledge {
+    pub parts: BTreeSet<IdPart>,
+    pub acks: BTreeMap<IdPart, BTreeSet<IdAck>>,
+    pub agreed_with_all_acks: BTreeSet<NodeId>,
+}
+
+#[derive(Error, Debug)]
+pub(crate) enum KnowledgeFault {
+    #[error("Missing Parts to deal with Acks in received vote")]
+    MissingParts,
+    #[error("Parts in received vote differ from ours")]
+    IncompatibleParts,
+    #[error("Missing Acks to deal with AllAcks in received vote")]
+    MissingAcks,
+    #[error("Acks received in vote differ from ours")]
+    IncompatibleAcks,
+}
+
+impl Knowledge {
+    fn new() -> Self {
+        Knowledge {
+            parts: BTreeSet::new(),
+            acks: BTreeMap::new(),
+            agreed_with_all_acks: BTreeSet::new(),
+        }
+    }
+
+    pub fn from_votes(mut votes: Vec<(DkgVote, NodeId)>) -> Result<Self, KnowledgeFault> {
+        votes.sort();
+        let mut knowledge = Knowledge::new();
+        for (vote, voter_id) in votes {
+            knowledge.handle_vote(vote, voter_id)?;
+        }
+
+        Ok(knowledge)
+    }
+
+    pub fn got_all_acks(&self, participants_len: usize) -> bool {
+        self.acks.len() == participants_len
+            && self.acks.iter().any(|(_, a)| a.len() != participants_len)
+    }
+
+    fn handle_vote(&mut self, vote: DkgVote, id: NodeId) -> Result<(), KnowledgeFault> {
+        match vote {
+            DkgVote::SinglePart(part) => {
+                self.parts.insert((id, part));
+            }
+            DkgVote::SingleAck(acked_parts) => {
+                let parts: BTreeSet<_> = acked_parts.keys().cloned().collect();
+                if self.parts.len() < parts.len() {
+                    return Err(KnowledgeFault::MissingParts);
+                } else if self.parts != parts {
+                    debug!(
+                        "IncompatibleParts: ours: {:?}, theirs: {:?}",
+                        self.parts, parts
+                    );
+                    return Err(KnowledgeFault::IncompatibleParts);
+                }
+                for (id_part, ack) in acked_parts {
+                    if let Some(entry) = self.acks.get_mut(&id_part) {
+                        entry.insert((id, ack));
+                    } else {
+                        self.acks.insert(id_part, BTreeSet::from([(id, ack)]));
+                    }
+                }
+            }
+            DkgVote::AllAcks(all_acks) => {
+                if !self.got_all_acks(self.parts.len()) {
+                    return Err(KnowledgeFault::MissingAcks);
+                } else if all_acks != self.acks {
+                    debug!(
+                        "IncompatibleAcks: ours: {:?}, theirs: {:?}",
+                        self.acks, all_acks
+                    );
+                    return Err(KnowledgeFault::IncompatibleAcks);
+                }
+                self.agreed_with_all_acks.insert(id);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,12 @@
 // under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 // KIND, either express or implied. Please review the Licences for the specific language governing
 // permissions and limitations relating to use of the SAFE Network Software.
-//
-// The following code is based on hbbft : https://github.com/poanetwork/hbbft
-//
-// hbbft is copyright 2018, POA Networks, Ltd.
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
-// http://opensource.org/licenses/MIT>, at your option. All files in the project
-// carrying such notice may not be copied, modified, or distributed except
-// according to those terms.
 
-mod sdkg;
+pub(crate) mod error;
+pub(crate) mod knowledge;
+pub mod sdkg;
+mod state;
+pub(crate) mod vote;
 
-pub use sdkg::{to_pub_keys, AckOutcome, PartOutcome, SyncKeyGen};
+pub use error::Error;
+pub use state::{DkgState, VoteResponse};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub(crate) mod vote;
 
 pub use error::Error;
 pub use state::{DkgState, VoteResponse};
+pub use vote::DkgSignedVote;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,227 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bls::{PublicKey, PublicKeySet, SecretKey, SecretKeyShare};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+use crate::knowledge::{Knowledge, KnowledgeFault};
+use crate::sdkg::{AckOutcome, Part, PartOutcome, SyncKeyGen};
+use crate::vote::{DkgSignedVote, DkgVote, IdAck, IdPart, NodeId};
+
+/// State of the Dkg session, contains the sync keygen and currently known Parts and Acks
+/// Can handle votes coming from other participants
+pub struct DkgState<R: bls::rand::RngCore> {
+    id: NodeId,
+    secret_key: SecretKey,
+    pub_keys: BTreeMap<NodeId, PublicKey>,
+    keygen: SyncKeyGen<NodeId>,
+    our_part: Part,
+    all_votes: BTreeSet<DkgSignedVote>,
+    outcome: Option<(PublicKeySet, SecretKeyShare)>,
+    rng: R,
+}
+
+pub enum VoteResponse {
+    WaitingForMoreVotes,
+    BroadcastVote(Box<DkgSignedVote>),
+    RequestAntiEntropy,
+    AntiEntropy(BTreeSet<DkgSignedVote>),
+    DkgComplete(PublicKeySet, SecretKeyShare),
+}
+
+enum DkgCurrentState {
+    IncompatibleVotes,
+    NeedAntiEntropy,
+    Termination(BTreeMap<IdPart, BTreeSet<IdAck>>),
+    WaitingForTotalAgreement,
+    GotAllAcks(BTreeMap<IdPart, BTreeSet<IdAck>>),
+    WaitingForMoreAcks,
+    GotAllParts(BTreeSet<IdPart>),
+    WaitingForMoreParts,
+}
+
+impl<R: bls::rand::RngCore + Clone> DkgState<R> {
+    pub fn from(
+        our_id: NodeId,
+        secret_key: SecretKey,
+        pub_keys: BTreeMap<NodeId, PublicKey>,
+        threshold: usize,
+        rng: &mut R,
+    ) -> Result<Self> {
+        let (sync_key_gen, opt_part) = SyncKeyGen::new(
+            our_id,
+            secret_key.clone(),
+            Arc::new(pub_keys.clone()),
+            threshold,
+            rng,
+        )?;
+        Ok(DkgState {
+            id: our_id,
+            secret_key,
+            pub_keys,
+            keygen: sync_key_gen,
+            all_votes: BTreeSet::new(),
+            our_part: opt_part.ok_or(Error::NotInPubKeySet)?,
+            outcome: None,
+            rng: rng.clone(),
+        })
+    }
+
+    /// The 1st vote with our Part
+    pub fn first_vote(&mut self) -> Result<DkgSignedVote> {
+        let vote = DkgVote::SinglePart(self.our_part.clone());
+        self.cast_vote(vote)
+    }
+
+    /// The outcome of this DKG, either Some keys of None if not finished
+    pub fn outcome(&self) -> Option<(PublicKeySet, SecretKeyShare)> {
+        self.outcome.clone()
+    }
+
+    fn get_validated_vote(&self, vote: &DkgSignedVote) -> Result<DkgVote> {
+        let sender_id = vote.voter;
+        let sender_pub_key = self.pub_keys.get(&sender_id).ok_or(Error::UnknownSender)?;
+        let vote = vote.get_validated_vote(sender_pub_key)?;
+        Ok(vote)
+    }
+
+    fn all_checked_votes(&self) -> Result<Vec<(DkgVote, NodeId)>> {
+        self.all_votes
+            .iter()
+            .map(|v| Ok((self.get_validated_vote(v)?, v.voter)))
+            .collect()
+    }
+
+    fn current_dkg_state(&self, votes: Vec<(DkgVote, NodeId)>) -> DkgCurrentState {
+        let knowledge = match Knowledge::from_votes(votes) {
+            Err(KnowledgeFault::IncompatibleAcks) | Err(KnowledgeFault::IncompatibleParts) => {
+                return DkgCurrentState::IncompatibleVotes;
+            }
+            Err(KnowledgeFault::MissingParts) | Err(KnowledgeFault::MissingAcks) => {
+                return DkgCurrentState::NeedAntiEntropy;
+            }
+            Ok(k) => k,
+        };
+
+        let participants_len = self.pub_keys.len();
+        if knowledge.agreed_with_all_acks.len() == participants_len {
+            DkgCurrentState::Termination(knowledge.acks)
+        } else if !knowledge.agreed_with_all_acks.is_empty() {
+            DkgCurrentState::WaitingForTotalAgreement
+        } else if knowledge.got_all_acks(participants_len) {
+            DkgCurrentState::GotAllAcks(knowledge.acks)
+        } else if !knowledge.acks.is_empty() {
+            DkgCurrentState::WaitingForMoreAcks
+        } else if knowledge.parts.len() == participants_len {
+            DkgCurrentState::GotAllParts(knowledge.parts)
+        } else {
+            DkgCurrentState::WaitingForMoreParts
+        }
+    }
+
+    /// Sign, log and return the vote
+    fn cast_vote(&mut self, vote: DkgVote) -> Result<DkgSignedVote> {
+        let sig = self.secret_key.sign(&bincode::serialize(&vote)?);
+        let signed_vote = DkgSignedVote::from(vote, self.id, sig);
+        self.all_votes.insert(signed_vote.clone());
+        Ok(signed_vote)
+    }
+
+    /// Handles all the Acks
+    fn handle_all_acks(&mut self, all_acks: BTreeMap<IdPart, BTreeSet<IdAck>>) -> Result<()> {
+        for ((part_id, _part), acks) in all_acks {
+            for (sender_id, ack) in acks {
+                let outcome = self.keygen.handle_ack(&sender_id, ack.clone())?;
+                if let AckOutcome::Invalid(fault) = outcome {
+                    return Err(Error::FaultyVote(format!(
+                        "Ack fault: {:?} by {:?} for part by {:?}",
+                        fault, sender_id, part_id
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Handles the Parts to create the Acks
+    fn parts_into_acks(&mut self, parts: BTreeSet<IdPart>) -> Result<DkgVote> {
+        let mut acks = BTreeMap::new();
+        for (sender_id, part) in parts {
+            match self
+                .keygen
+                .handle_part(&sender_id, part.clone(), &mut self.rng)?
+            {
+                PartOutcome::Valid(Some(ack)) => {
+                    acks.insert((sender_id, part), ack);
+                }
+                PartOutcome::Invalid(fault) => {
+                    return Err(Error::FaultyVote(format!(
+                        "Part fault: {:?} by {:?}",
+                        fault, sender_id
+                    )));
+                }
+                PartOutcome::Valid(None) => {
+                    // code smell: we don't have observer nodes and we can't end up here if we've
+                    // handled parts and given our acks already, this should not happen unless our
+                    // votes were corrupted
+                    return Err(Error::FaultyVote("unexpected part outcome, node is faulty or keygen already handled this part".to_string()));
+                }
+            }
+        }
+        Ok(DkgVote::SingleAck(acks))
+    }
+
+    /// Returns all the votes that we received as an anti entropy update
+    pub fn handle_ae(&self) -> VoteResponse {
+        VoteResponse::AntiEntropy(self.all_votes.clone())
+    }
+
+    /// Handle a DKG vote, save the information if we learned any, broadcast when:
+    /// - SingleAck when got all parts
+    /// - AllAcks when got all acks
+    /// Consider we reached completion when we received everyone's signatures over the AllAcks
+    pub fn handle_signed_vote(&mut self, msg: DkgSignedVote) -> Result<VoteResponse> {
+        // immediately bail if signature check fails
+        self.get_validated_vote(&msg)?;
+
+        // update knowledge with vote
+        self.all_votes.insert(msg);
+        let votes = self.all_checked_votes()?;
+        let dkg_state = self.current_dkg_state(votes);
+
+        // act accordingly
+        match dkg_state {
+            DkgCurrentState::NeedAntiEntropy => Ok(VoteResponse::RequestAntiEntropy),
+            DkgCurrentState::Termination(acks) => {
+                self.handle_all_acks(acks)?;
+                if let (pubs, Some(sec)) = self.keygen.generate()? {
+                    self.outcome = Some((pubs.clone(), sec.clone()));
+                    Ok(VoteResponse::DkgComplete(pubs, sec))
+                } else {
+                    Err(Error::FailedToGenerateSecretKeyShare)
+                }
+            }
+            DkgCurrentState::GotAllAcks(acks) => {
+                let vote = DkgVote::AllAcks(acks);
+                Ok(VoteResponse::BroadcastVote(Box::new(self.cast_vote(vote)?)))
+            }
+            DkgCurrentState::GotAllParts(parts) => {
+                let vote = self.parts_into_acks(parts)?;
+                Ok(VoteResponse::BroadcastVote(Box::new(self.cast_vote(vote)?)))
+            }
+            DkgCurrentState::WaitingForMoreParts
+            | DkgCurrentState::WaitingForMoreAcks
+            | DkgCurrentState::WaitingForTotalAgreement => Ok(VoteResponse::WaitingForMoreVotes),
+            DkgCurrentState::IncompatibleVotes => {
+                Err(Error::FaultyVote("got incompatible votes".to_string()))
+            }
+        }
+    }
+}

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -1,0 +1,64 @@
+// Copyright 2022 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under The General Public License (GPL), version 3.
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. Please review the Licences for the specific language governing
+// permissions and limitations relating to use of the SAFE Network Software.
+
+use bls::{PublicKey, Signature};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::{Error, Result};
+use crate::sdkg::{Ack, Part};
+
+pub(crate) type NodeId = u8;
+pub(crate) type IdPart = (NodeId, Part);
+pub(crate) type IdAck = (NodeId, Ack);
+
+// The order of entries in this enum is IMPORTANT
+// Its the order in which they should be handled
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+pub enum DkgVote {
+    /// Participant's own Part
+    SinglePart(Part),
+    /// Participant's own Ack over everybody's Parts
+    SingleAck(BTreeMap<IdPart, Ack>),
+    /// All participants' Acks over every Parts, should be identical for all participants
+    AllAcks(BTreeMap<IdPart, BTreeSet<IdAck>>),
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+pub struct DkgSignedVote {
+    /// This field is private to ensure votes are always signature-checked
+    vote: DkgVote,
+    /// The id of the voter
+    pub voter: NodeId,
+    /// The bls signature of the voter
+    pub sig: Signature,
+}
+
+fn verify_sig<M: Serialize>(msg: &M, sig: &Signature, public_key: &PublicKey) -> Result<()> {
+    let msg_bytes = bincode::serialize(msg)?;
+    if public_key.verify(sig, msg_bytes) {
+        Ok(())
+    } else {
+        Err(Error::InvalidSignature)
+    }
+}
+
+impl DkgSignedVote {
+    /// Creates a new DkgSignedVote from a DkgVote
+    pub fn from(vote: DkgVote, voter: NodeId, sig: Signature) -> Self {
+        DkgSignedVote { vote, voter, sig }
+    }
+
+    /// Gets a DkgVote out of a DkgSignedVote and checks the signature as well as the content
+    /// This method is the only way to obtain the underlying DkgVote,
+    /// this helps ensure signatures are always checked before we can access votes
+    pub fn get_validated_vote(&self, public_key: &PublicKey) -> Result<DkgVote> {
+        verify_sig(&self.vote, &self.sig, public_key)?;
+        Ok(self.vote.clone())
+    }
+}


### PR DESCRIPTION
This PR includes voting mechanisms for SDKG:
- one round broadcasting Parts
- one round broadcasting Acks over these Parts
- one round broadcasting all the Acks over all the Parts, ensuring all the participants have the same sets (Acks and Parts)
- termination once we've seen everyone's signature over those sets

Basic AE:
- we deal with packet loss with `RequestAntiEntropy` responses
- we have an `AntiEntropy` type containing all the votes we need to send to make AE requesting nodes catchup

We still need:
- tests
- proptests