### PR TITLE
Differentiate key threshold and parts completeness threshold 

### DIFF
--- a/src/sdkg.rs
+++ b/src/sdkg.rs
@@ -694,7 +694,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dkg_threshold() {
+    fn test_threshold() {
         for nodes_num in 2..10 {
             // for threshold in 1..((nodes_num-1)/2+1) {
             for threshold in 1..nodes_num {

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,9 +49,10 @@ impl<R: bls::rand::RngCore + Clone> DkgState<R> {
         our_id: NodeId,
         secret_key: SecretKey,
         pub_keys: BTreeMap<NodeId, PublicKey>,
-        threshold: usize,
         rng: &mut R,
     ) -> Result<Self> {
+        // The number of nodes must be at least 2 * threshold + 1
+        let threshold = (pub_keys.len() - 1) / 2;
         let (sync_key_gen, opt_part) =
             SyncKeyGen::new(our_id, secret_key.clone(), pub_keys.clone(), threshold, rng)?;
         Ok(DkgState {

--- a/src/state.rs
+++ b/src/state.rs
@@ -49,10 +49,9 @@ impl<R: bls::rand::RngCore + Clone> DkgState<R> {
         our_id: NodeId,
         secret_key: SecretKey,
         pub_keys: BTreeMap<NodeId, PublicKey>,
+        threshold: usize,
         rng: &mut R,
     ) -> Result<Self> {
-        // The number of nodes must be at least 2 * threshold + 1
-        let threshold = (pub_keys.len() - 1) / 2;
         let (sync_key_gen, opt_part) =
             SyncKeyGen::new(our_id, secret_key.clone(), pub_keys.clone(), threshold, rng)?;
         Ok(DkgState {

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -129,15 +129,15 @@ impl Net {
             packet.vote, packet.dest, resp
         );
         match resp {
-            Ok(VoteResponse::WaitingForMoreVotes) => {}
-            Ok(VoteResponse::BroadcastVote(vote)) => {
+            Ok((VoteResponse::WaitingForMoreVotes, _is_new_vote)) => {}
+            Ok((VoteResponse::BroadcastVote(vote), _is_new_vote)) => {
                 let dest_actor = packet.dest;
                 self.broadcast(dest_actor, *vote);
             }
-            Ok(VoteResponse::RequestAntiEntropy) => {
+            Ok((VoteResponse::RequestAntiEntropy, _is_new_vote)) => {
                 // AE TODO
             }
-            Ok(VoteResponse::DkgComplete(_pub_keys, _sec_key)) => {
+            Ok((VoteResponse::DkgComplete(_pub_keys, _sec_key), _is_new_vote)) => {
                 info!("[NET] DkgComplete for {:?}", packet.dest);
                 // Termination TODO
             }

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -31,7 +31,7 @@ pub struct Net {
 }
 
 impl Net {
-    pub fn with_procs(threshold: usize, n: usize, rng: &mut OsRng) -> Self {
+    pub fn with_procs(n: usize, rng: &mut OsRng) -> Self {
         let sec_keys: Vec<SecretKey> = (0..n).map(|_| bls::rand::random()).collect();
         let pub_keys: BTreeMap<NodeId, PublicKey> = sec_keys
             .iter()
@@ -48,7 +48,6 @@ impl Net {
                     id as NodeId,
                     sec_key.clone(),
                     pub_keys.clone(),
-                    threshold,
                     rng,
                 )
                 .unwrap()

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -31,7 +31,7 @@ pub struct Net {
 }
 
 impl Net {
-    pub fn with_procs(n: usize, rng: &mut OsRng) -> Self {
+    pub fn with_procs(threshold: usize, n: usize, rng: &mut OsRng) -> Self {
         let sec_keys: Vec<SecretKey> = (0..n).map(|_| bls::rand::random()).collect();
         let pub_keys: BTreeMap<NodeId, PublicKey> = sec_keys
             .iter()
@@ -48,6 +48,7 @@ impl Net {
                     id as NodeId,
                     sec_key.clone(),
                     pub_keys.clone(),
+                    threshold,
                     rng,
                 )
                 .unwrap()

--- a/tests/sdkg.rs
+++ b/tests/sdkg.rs
@@ -25,9 +25,9 @@ fn init() {
 #[test]
 fn test_normal_dkg_no_packet_drops() {
     init();
-    // make network of 10 members
+    // make network of 7 members
     let mut rng = bls::rand::rngs::OsRng;
-    let mut net = Net::with_procs(7, 10, &mut rng);
+    let mut net = Net::with_procs(7, &mut rng);
 
     // bcast everyone's first Part
     let all_parts: Vec<_> = net
@@ -65,7 +65,7 @@ fn test_dkg_inconsistant_votes() {
     init();
     // make network of 1 evil doer (id 0) and 2 good members
     let mut rng = bls::rand::rngs::OsRng;
-    let mut net = Net::with_procs(2, 3, &mut rng);
+    let mut net = Net::with_procs(3, &mut rng);
 
     // get everyone's first Part
     let all_parts: Vec<_> = net

--- a/tests/sdkg.rs
+++ b/tests/sdkg.rs
@@ -25,9 +25,9 @@ fn init() {
 #[test]
 fn test_normal_dkg_no_packet_drops() {
     init();
-    // make network of 7 members
+    // make network of 10 members
     let mut rng = bls::rand::rngs::OsRng;
-    let mut net = Net::with_procs(7, &mut rng);
+    let mut net = Net::with_procs(7, 10, &mut rng);
 
     // bcast everyone's first Part
     let all_parts: Vec<_> = net
@@ -65,7 +65,7 @@ fn test_dkg_inconsistant_votes() {
     init();
     // make network of 1 evil doer (id 0) and 2 good members
     let mut rng = bls::rand::rngs::OsRng;
-    let mut net = Net::with_procs(3, &mut rng);
+    let mut net = Net::with_procs(2, 3, &mut rng);
 
     // get everyone's first Part
     let all_parts: Vec<_> = net


### PR DESCRIPTION
It seems to me that sdkg is using the `key threshold` as a `part completeness threshold`. 
From Poanetwork's Keygen docs:

> A `Part` is _complete_ if it received at least _2 t + 1_ valid `Ack`s.
> The protocol succeeds if up to _t_ nodes are faulty, where _t_ is the `threshold` parameter. 
> The number of nodes must be at least _2 t + 1_.

This adds a restriction to the generated key's threshold.  
For the SAFE Network we use a 5 of 7 key scheme. This means a threshold (`t`) of 4 with 7 key shares (`n`). 
This doesn't match the constraint: `2 * t + 1 <= n` as `2 * 4 + 1 > 7`.

The underlying bls lib supports 5 of 7 and does not have this constraint. 

I'm assuming Poanetwork used the `threshold` input param for both the `part completeness threshold` and the `key threshold`. 

This PR differentiates the `part completeness threshold` and the `key threshold` in the sdkg code thus enabling us to use an unrestrained threshold for the key scheme. 

I believe allowing this should be safe as it only moves the `key threshold` further away from the amount of faulty nodes `t` but I have close to no bls math background to back this assumption. 