### PR TITLE
feat: ignore known votes

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -26,6 +26,7 @@ impl fmt::Debug for VoteResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             VoteResponse::WaitingForMoreVotes => write!(f, "WaitingForMoreVotes"),
+            VoteResponse::IgnoringKnownVote => write!(f, "IgnoringKnownVote"),
             VoteResponse::BroadcastVote(v) => write!(f, "BroadcastVote {:?}", *v),
             VoteResponse::RequestAntiEntropy => write!(f, "RequestAntiEntropy"),
             VoteResponse::DkgComplete(_, _) => write!(f, "DkgComplete"),

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -129,15 +129,16 @@ impl Net {
             packet.vote, packet.dest, resp
         );
         match resp {
-            Ok((VoteResponse::WaitingForMoreVotes, _is_new_vote)) => {}
-            Ok((VoteResponse::BroadcastVote(vote), _is_new_vote)) => {
+            Ok(VoteResponse::WaitingForMoreVotes) => {}
+            Ok(VoteResponse::IgnoringKnownVote) => {}
+            Ok(VoteResponse::BroadcastVote(vote)) => {
                 let dest_actor = packet.dest;
                 self.broadcast(dest_actor, *vote);
             }
-            Ok((VoteResponse::RequestAntiEntropy, _is_new_vote)) => {
+            Ok(VoteResponse::RequestAntiEntropy) => {
                 // AE TODO
             }
-            Ok((VoteResponse::DkgComplete(_pub_keys, _sec_key), _is_new_vote)) => {
+            Ok(VoteResponse::DkgComplete(_pub_keys, _sec_key)) => {
                 info!("[NET] DkgComplete for {:?}", packet.dest);
                 // Termination TODO
             }


### PR DESCRIPTION
Ignores votes that we know already instead of reprocessing them, which can be very demanding. 