### PR TITLE
feat: make outcome imut

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -212,11 +212,11 @@ impl DkgState {
     }
 
     /// After termination, returns Some keypair else returns None
-    // NB: it recomputes everything from current knowledge instead of using a cached result
-    pub fn outcome(&mut self) -> Result<Option<(PublicKeySet, SecretKeyShare)>> {
+    /// This function assumes that the Acks have been processed before hand
+    /// when receiving the final ack vote
+    pub fn outcome(&self) -> Result<Option<(PublicKeySet, SecretKeyShare)>> {
         let votes = self.all_checked_votes()?;
-        if let DkgCurrentState::Termination(acks) = self.current_dkg_state(votes) {
-            self.handle_all_acks(acks)?;
+        if let DkgCurrentState::Termination(_) = self.current_dkg_state(votes) {
             if let (pubs, Some(sec)) = self.keygen.generate()? {
                 Ok(Some((pubs, sec)))
             } else {

--- a/tests/sdkg.rs
+++ b/tests/sdkg.rs
@@ -50,7 +50,7 @@ fn test_normal_dkg_no_packet_drops() {
 
     // check that everyone reached termination on the same pubkeyset
     let mut pubs = BTreeSet::new();
-    for mut node in net.procs.into_iter() {
+    for node in net.procs.into_iter() {
         let (pks, _sks) = node
             .outcome()
             .expect("Unexpectedly failed to generate keypair")
@@ -94,7 +94,7 @@ fn test_dkg_inconsistant_votes() {
     assert!(matches!(res, Err(Error::FaultyVote(_))));
 
     // check that no one reached termination
-    for mut node in net.procs.into_iter() {
+    for node in net.procs.into_iter() {
         assert!(node.outcome().unwrap().is_none())
     }
 }


### PR DESCRIPTION
`outcome` use to process `acks` (thus mutating DkgState) before generating the key, but it seems it is not useful as they are processed whenever we receive the final `all_ack`. 

This extra safety is not needed as only votes handling can add to the vote list. 