### PR TITLE
chore: use different version bumping action for debugging

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump Version
-        uses: maidsafe/rust-version-bump-branch-creator@v2
+        uses: jacderida/rust-version-bump-branch-creator@debugging-info
         with:
           token: ${{ secrets.BRANCH_CREATOR_TOKEN }}


### PR DESCRIPTION
There is some kind of problem on this repository with the creation of a PR in the version bumping process. I've added some extra debugging information on a branch of the version bumping tool.