### PR TITLE
chore: switch back to main version bumping action

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump Version
-        uses: jacderida/rust-version-bump-branch-creator@debugging-info
+        uses: maidsafe/rust-version-bump-branch-creator@v2
         with:
           token: ${{ secrets.BRANCH_CREATOR_TOKEN }}


### PR DESCRIPTION
It appears that modifying settings in the repository solved this problem, so we should be able to switch back to the main version of the action.