### PR TITLE
fix: issue when we are last to ack, we dont send allacks

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -130,6 +130,15 @@ impl DkgState {
         }
     }
 
+    // checks in our current knowledge if we sent our AllAcks
+    fn we_sent_our_all_acks(&self) -> bool {
+        let our_id = self.id();
+        self.all_votes
+            .iter()
+            .filter(|v| v.is_all_acks())
+            .any(|v| v.voter == our_id)
+    }
+
     // Current DKG state taking last vote's type into account
     fn dkg_state_with_vote(
         &self,
@@ -146,10 +155,9 @@ impl DkgState {
             {
                 DkgCurrentState::GotAllParts(parts)
             }
-            // Similarly this happens when we receive the last Ack but we already received
-            // someone's agreement on all acks before, making us skip GotAllAcks
+            // Another case is when we didn't send our own AllAcks yet
             DkgCurrentState::WaitingForTotalAgreement(part_acks)
-                if is_new && matches!(vote, DkgVote::SingleAck(_)) =>
+                if !self.we_sent_our_all_acks() =>
             {
                 DkgCurrentState::GotAllAcks(part_acks)
             }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -69,4 +69,9 @@ impl DkgSignedVote {
         verify_sig(&self.vote, &self.sig, public_key)?;
         Ok(self.vote.clone())
     }
+
+    /// Helper that checks if underlying vote is AllAcks
+    pub(crate) fn is_all_acks(&self) -> bool {
+        matches!(self.vote, DkgVote::AllAcks(_))
+    }
 }


### PR DESCRIPTION
This fixes a rare issue that can happen when :
- we receive everyone's `Ack` before we send ours out
- the next vote we receive is an `AllAcks`
- we wait for more `AllAcks` as we don't have them all
- we never send ours

Since we don't handle our own votes and since we don't ever receive a knowledge changing `Ack`, we never switch to the `GotAllAcks` state that triggers sending our `AllAcks`