### PR TITLE
ci: Revert "chore: switch back to main version bumping action"

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -19,6 +19,6 @@ jobs:
         with:
           fetch-depth: '0'
       - name: Bump Version
-        uses: maidsafe/rust-version-bump-branch-creator@v2
+        uses: jacderida/rust-version-bump-branch-creator@debugging-info
         with:
           token: ${{ secrets.BRANCH_CREATOR_TOKEN }}


### PR DESCRIPTION
This reverts commit b73faacf1531fd7c156c35445d9f47b287915d9a.

Reverting to a stage where the version bump github action worked