### PR TITLE
Return empty vec for known votes

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -26,7 +26,6 @@ impl fmt::Debug for VoteResponse {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             VoteResponse::WaitingForMoreVotes => write!(f, "WaitingForMoreVotes"),
-            VoteResponse::IgnoringKnownVote => write!(f, "IgnoringKnownVote"),
             VoteResponse::BroadcastVote(v) => write!(f, "BroadcastVote {:?}", *v),
             VoteResponse::RequestAntiEntropy => write!(f, "RequestAntiEntropy"),
             VoteResponse::DkgComplete(_, _) => write!(f, "DkgComplete"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,12 +73,9 @@ mod tests {
         // Handle the other participants Parts, obtain Acks
         // No need to handle our own vote
         // Participant 0 handles Parts
-        // We already know this vote (it's ours), just checking that it gives IgnoringKnownVote
+        // We already know this vote (it's ours), just checking that it gives vec![]
         let res = &dkg_state0.handle_signed_vote(part0.clone(), &mut rng);
-        assert!(matches!(
-            res.as_deref(),
-            Ok([VoteResponse::IgnoringKnownVote])
-        ));
+        assert!(matches!(res.as_deref(), Ok([])));
         let res = &dkg_state0.handle_signed_vote(part1.clone(), &mut rng);
         assert!(matches!(
             res.as_deref(),

--- a/src/state.rs
+++ b/src/state.rs
@@ -29,8 +29,6 @@ pub struct DkgState {
 pub enum VoteResponse {
     /// We need more votes to decide on anything yet
     WaitingForMoreVotes,
-    /// This vote has already been processed
-    IgnoringKnownVote,
     /// Broadcast our vote to the other participants
     BroadcastVote(Box<DkgSignedVote>),
     /// We are missing information to understand this vote
@@ -269,6 +267,8 @@ impl DkgState {
     /// - SingleAck when got all parts
     /// - AllAcks when got all acks
     /// Consider we reached completion when we received everyone's signatures over the AllAcks
+    /// Return a vec with the reactions to the handled vote
+    /// An empty vec means we didn't learn anything from this msg because we alread received it
     pub fn handle_signed_vote<R: bls::rand::RngCore>(
         &mut self,
         msg: DkgSignedVote,
@@ -276,7 +276,7 @@ impl DkgState {
     ) -> Result<Vec<VoteResponse>> {
         // if already seen it, ignore it
         if self.all_votes.contains(&msg) {
-            return Ok(vec![VoteResponse::IgnoringKnownVote]);
+            return Ok(vec![]);
         }
 
         // immediately bail if signature check fails

--- a/src/state.rs
+++ b/src/state.rs
@@ -305,9 +305,11 @@ impl DkgState {
                 let signed_vote = self.signed_vote(vote)?;
                 let mut res = vec![VoteResponse::BroadcastVote(Box::new(signed_vote.clone()))];
                 let our_vote_res = self.handle_signed_vote(signed_vote, rng)?;
-                if !matches!(our_vote_res.as_slice(), [VoteResponse::WaitingForMoreVotes]) {
-                    res.extend(our_vote_res);
-                }
+                res.extend(
+                    our_vote_res
+                        .into_iter()
+                        .filter(|r| !matches!(r, VoteResponse::WaitingForMoreVotes)),
+                );
                 Ok(res)
             }
             DkgCurrentState::GotAllParts(parts) => {
@@ -315,9 +317,11 @@ impl DkgState {
                 let signed_vote = self.signed_vote(vote)?;
                 let mut res = vec![VoteResponse::BroadcastVote(Box::new(signed_vote.clone()))];
                 let our_vote_res = self.handle_signed_vote(signed_vote, rng)?;
-                if !matches!(our_vote_res.as_slice(), [VoteResponse::WaitingForMoreVotes]) {
-                    res.extend(our_vote_res);
-                }
+                res.extend(
+                    our_vote_res
+                        .into_iter()
+                        .filter(|r| !matches!(r, VoteResponse::WaitingForMoreVotes)),
+                );
                 Ok(res)
             }
             DkgCurrentState::WaitingForMoreParts

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -139,7 +139,6 @@ impl Net {
         for r in res {
             match r {
                 VoteResponse::WaitingForMoreVotes => {}
-                VoteResponse::IgnoringKnownVote => {}
                 VoteResponse::BroadcastVote(vote) => {
                     let dest_actor = packet.dest;
                     self.broadcast(dest_actor, *vote);


### PR DESCRIPTION
BREAKING CHANGE: vote response API changes

Replaces IgnoringKnownVotes with `vec![]` and return a non-empty vec when we actually learned something from the vote we just handled.

For context, we return `WaitingForMoreVotes` when we receive a new vote but this vote alone isn’t enough to make us change state. When receiving a vote we already know, we return `IgnoringMoreVotes`.
Returning something could be akin to say “I’ve learned something here is my reaction”, and returning an empty vec would mean “I’ve learned nothing”.