### PR TITLE
test: fuzz test to ensure that DKG completes regardless of the order in which the `Votes` are handled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ log = "0.4.13"
 
 [dev-dependencies]
 env_logger = "0.8"
+eyre = "~0.6.5"
 # quickcheck = "1"
 # quickcheck_macros = "1"

--- a/src/state.rs
+++ b/src/state.rs
@@ -339,6 +339,8 @@ impl DkgState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{sdkg::tests::verify_threshold, vote::test_utils::*};
+    use bls::rand::{rngs::StdRng, seq::IteratorRandom, thread_rng, Rng, RngCore, SeedableRng};
 
     #[test]
     fn test_recursive_handle_vote() {
@@ -364,5 +366,520 @@ mod tests {
         assert!(matches!(res[1], VoteResponse::BroadcastVote(_)));
         assert!(matches!(res[2], VoteResponse::DkgComplete(_, _)));
         assert_eq!(res.len(), 3);
+    }
+
+    #[test]
+    fn fuzz_test() -> Result<()> {
+        let mut fuzz_count = 20;
+        let mut rng_for_seed = thread_rng();
+        let num_nodes = 7;
+        let threshold = 4;
+
+        while fuzz_count != 0 {
+            let seed = rng_for_seed.gen();
+            println!(" SEED {seed:?} => count_remaining: {fuzz_count}");
+            let mut rng = StdRng::seed_from_u64(seed);
+
+            let mut nodes = generate_nodes(num_nodes, threshold, &mut rng)?;
+            let mut parts: BTreeMap<usize, DkgSignedVote> = BTreeMap::new();
+            let mut acks: BTreeMap<usize, DkgSignedVote> = BTreeMap::new();
+            let mut all_acks: BTreeMap<usize, DkgSignedVote> = BTreeMap::new();
+            let mut sk_shares: BTreeMap<usize, SecretKeyShare> = BTreeMap::new();
+            let mut pk_set: BTreeSet<PublicKeySet> = BTreeSet::new();
+
+            for node in nodes.iter_mut() {
+                parts.insert(node.id() as usize, node.first_vote()?);
+            }
+
+            for cmd in fuzz_commands(num_nodes, seed) {
+                // println!("==> {cmd:?}");
+                match cmd {
+                    SendVote::Parts(from_node, to_nodes) => {
+                        for (to, expt_resp) in to_nodes {
+                            let actual_resp = nodes[to]
+                                .handle_signed_vote(parts[&from_node].clone(), &mut rng)?;
+                            assert_eq!(expt_resp.len(), actual_resp.len());
+                            expt_resp.into_iter().zip(actual_resp.into_iter()).for_each(
+                                |(exp, actual)| {
+                                    assert!(exp.match_resp(
+                                        actual,
+                                        &mut acks,
+                                        &mut all_acks,
+                                        &mut sk_shares,
+                                        &mut pk_set,
+                                        to
+                                    ));
+                                },
+                            )
+                        }
+                    }
+                    SendVote::Acks(from_node, to_nodes) => {
+                        for (to, expt_resp) in to_nodes {
+                            let actual_resp =
+                                nodes[to].handle_signed_vote(acks[&from_node].clone(), &mut rng)?;
+                            assert_eq!(expt_resp.len(), actual_resp.len());
+                            expt_resp.into_iter().zip(actual_resp.into_iter()).for_each(
+                                |(exp, actual)| {
+                                    assert!(exp.match_resp(
+                                        actual,
+                                        &mut acks,
+                                        &mut all_acks,
+                                        &mut sk_shares,
+                                        &mut pk_set,
+                                        to
+                                    ));
+                                },
+                            )
+                        }
+                    }
+                    SendVote::AllAcks(from_node, to_nodes) => {
+                        for (to, expt_resp) in to_nodes {
+                            let actual_resp = nodes[to]
+                                .handle_signed_vote(all_acks[&from_node].clone(), &mut rng)?;
+                            assert_eq!(expt_resp.len(), actual_resp.len());
+                            expt_resp.into_iter().zip(actual_resp.into_iter()).for_each(
+                                |(exp, actual)| {
+                                    assert!(exp.match_resp(
+                                        actual,
+                                        &mut acks,
+                                        &mut all_acks,
+                                        &mut sk_shares,
+                                        &mut pk_set,
+                                        to
+                                    ));
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+
+            assert_eq!(pk_set.len(), 1);
+            let pk_set = pk_set.into_iter().collect::<Vec<_>>()[0].clone();
+            let sk_shares: Vec<_> = sk_shares.into_iter().collect();
+
+            assert!(verify_threshold(threshold, &sk_shares, &pk_set).is_ok());
+            fuzz_count -= 1;
+        }
+        Ok(())
+    }
+
+    // Returns a list of `SendVote` which when executed in that order will simulate a DKG round from start to completion
+    // for each node
+    fn fuzz_commands(num_nodes: usize, seed: u64) -> Vec<SendVote> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut nodes = MockNode::new(num_nodes);
+        // probability for a node to resend vote to another node which has already handled it.
+        let resend_probability = Some((1, 10));
+        // these nodes are required to help other nodes terminate
+        let mut active_nodes = MockNode::active_nodes(&nodes);
+        let mut commands = Vec::new();
+
+        while !active_nodes.is_empty() {
+            // get a random active node
+            let current_node = active_nodes[rng.gen::<usize>() % active_nodes.len()];
+
+            // check if current_node can send part/acks/all_acks.
+            let parts = nodes[current_node].can_send_parts(&nodes, resend_probability, &mut rng);
+            let acks = nodes[current_node].can_send_acks(&nodes, resend_probability, &mut rng);
+            let all_acks =
+                nodes[current_node].can_send_all_acks(&nodes, resend_probability, &mut rng);
+
+            // continue if current_node cant progress
+            if parts.is_empty() && acks.is_empty() && all_acks.is_empty() {
+                continue;
+            }
+
+            // randomly send out part/acks/all_acks
+            match rng.gen::<usize>() % 3 {
+                0 if !parts.is_empty() => {
+                    let to_nodes = MockNode::sample_nodes(&parts, &mut rng);
+
+                    // update each `to` node and get its (id, response)
+                    let to_nodes_resp = to_nodes
+                        .into_iter()
+                        .map(|to| {
+                            let mut resp = Vec::new();
+                            // skip if already handled
+                            if let Some(val) = nodes[to].handled_parts.get(&current_node) {
+                                if *val {
+                                    return (to, resp);
+                                }
+                            }
+
+                            if let Some(val) = nodes[to].handled_parts.insert(current_node, true) {
+                                if nodes[to].parts_done() {
+                                    resp.push(MockVoteResponse::BroadcastVote(
+                                        MockDkgVote::SingleAck,
+                                    ));
+                                    // if we have handled the all the `Acks` before the parts
+                                    if nodes[to].acks_done() {
+                                        resp.push(MockVoteResponse::BroadcastVote(
+                                            MockDkgVote::AllAcks,
+                                        ));
+                                    }
+                                } else {
+                                    // if false, we need more votes
+                                    if !val {
+                                        resp.push(MockVoteResponse::WaitingForMoreVotes)
+                                    }
+                                }
+                            }
+
+                            (to, resp)
+                        })
+                        .collect();
+
+                    commands.push(SendVote::Parts(current_node, to_nodes_resp));
+                }
+                1 if !acks.is_empty() => {
+                    let to_nodes = MockNode::sample_nodes(&acks, &mut rng);
+
+                    let to_nodes_resp = to_nodes
+                        .into_iter()
+                        .map(|to| {
+                            let mut resp = Vec::new();
+                            // skip if already handled
+                            if let Some(val) = nodes[to].handled_acks.get(&current_node) {
+                                if *val {
+                                    return (to, resp);
+                                }
+                            }
+                            let res = nodes[to].handled_acks.insert(current_node, true);
+                            // if our parts are not done, we will not understand this vote
+                            if !nodes[to].parts_done() {
+                                resp.push(MockVoteResponse::RequestAntiEntropy)
+                            } else if let Some(val) = res {
+                                if nodes[to].acks_done() {
+                                    resp.push(MockVoteResponse::BroadcastVote(
+                                        MockDkgVote::AllAcks,
+                                    ));
+                                    // if we have handled the all the `AllAcks` before the Acks
+                                    if nodes[to].all_acks_done() {
+                                        resp.push(MockVoteResponse::DkgComplete);
+                                    }
+                                } else {
+                                    // if false, we need more votes
+                                    if !val {
+                                        resp.push(MockVoteResponse::WaitingForMoreVotes)
+                                    }
+                                }
+                            };
+
+                            (to, resp)
+                        })
+                        .collect();
+
+                    commands.push(SendVote::Acks(current_node, to_nodes_resp));
+                }
+                2 if !all_acks.is_empty() => {
+                    let to_nodes = MockNode::sample_nodes(&all_acks, &mut rng);
+
+                    let to_nodes_resp = to_nodes
+                        .into_iter()
+                        .map(|to| {
+                            let mut resp = Vec::new();
+                            // skip if already handled
+                            if let Some(val) = nodes[to].handled_all_acks.get(&current_node) {
+                                if *val {
+                                    return (to, resp);
+                                }
+                            }
+                            let res = nodes[to].handled_all_acks.insert(current_node, true);
+
+                            // if our Acks are not done, we will not understand this vote
+                            if !nodes[to].acks_done() {
+                                resp.push(MockVoteResponse::RequestAntiEntropy);
+                            } else if let Some(val) = res {
+                                if nodes[to].all_acks_done() {
+                                    resp.push(MockVoteResponse::DkgComplete)
+                                } else {
+                                    // if false, we need more votes
+                                    if !val {
+                                        resp.push(MockVoteResponse::WaitingForMoreVotes)
+                                    }
+                                }
+                            };
+                            (to, resp)
+                        })
+                        .collect();
+
+                    commands.push(SendVote::AllAcks(current_node, to_nodes_resp));
+                }
+                _ => {}
+            }
+
+            active_nodes = MockNode::active_nodes(&nodes);
+        }
+        commands
+    }
+
+    // Test helpers
+    fn generate_nodes<R: RngCore>(
+        num_nodes: usize,
+        threshold: usize,
+        mut rng: &mut R,
+    ) -> Result<Vec<DkgState>> {
+        let secret_keys: Vec<SecretKey> = (0..num_nodes).map(|_| bls::rand::random()).collect();
+        let pub_keys: BTreeMap<_, _> = secret_keys
+            .iter()
+            .enumerate()
+            .map(|(id, sk)| (id as u8, sk.public_key()))
+            .collect();
+        secret_keys
+            .iter()
+            .enumerate()
+            .map(|(id, sk)| {
+                DkgState::new(id as u8, sk.clone(), pub_keys.clone(), threshold, &mut rng)
+            })
+            .collect()
+    }
+
+    #[derive(Debug)]
+    enum SendVote {
+        // from_node, list of (to_node, vec of response when handled)
+        Parts(usize, Vec<(usize, Vec<MockVoteResponse>)>),
+        Acks(usize, Vec<(usize, Vec<MockVoteResponse>)>),
+        AllAcks(usize, Vec<(usize, Vec<MockVoteResponse>)>),
+    }
+
+    #[derive(Debug)]
+    enum MockVoteResponse {
+        WaitingForMoreVotes,
+        BroadcastVote(MockDkgVote),
+        RequestAntiEntropy,
+        DkgComplete,
+    }
+
+    impl MockVoteResponse {
+        pub fn match_resp(
+            &self,
+            actual_resp: VoteResponse,
+            update_acks: &mut BTreeMap<usize, DkgSignedVote>,
+            update_all_acks: &mut BTreeMap<usize, DkgSignedVote>,
+            update_sk: &mut BTreeMap<usize, SecretKeyShare>,
+            update_pk: &mut BTreeSet<PublicKeySet>,
+            id: usize,
+        ) -> bool {
+            if (matches!(self, Self::WaitingForMoreVotes)
+                && matches!(actual_resp, VoteResponse::WaitingForMoreVotes))
+                || (matches!(self, Self::RequestAntiEntropy)
+                    && matches!(actual_resp, VoteResponse::RequestAntiEntropy))
+            {
+                true
+            } else if matches!(self, Self::BroadcastVote(MockDkgVote::SingleAck)) {
+                match actual_resp {
+                    VoteResponse::BroadcastVote(vote)
+                        if matches!(vote.mock(), MockDkgVote::SingleAck) =>
+                    {
+                        update_acks.insert(id, *vote);
+                        true
+                    }
+                    _ => false,
+                }
+            } else if matches!(self, Self::BroadcastVote(MockDkgVote::AllAcks)) {
+                match actual_resp {
+                    VoteResponse::BroadcastVote(vote)
+                        if matches!(vote.mock(), MockDkgVote::AllAcks) =>
+                    {
+                        update_all_acks.insert(id, *vote);
+                        true
+                    }
+                    _ => false,
+                }
+            } else if matches!(self, Self::DkgComplete) {
+                if let VoteResponse::DkgComplete(pk, sk) = actual_resp {
+                    update_pk.insert(pk);
+                    update_sk.insert(id, sk);
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockNode {
+        id: usize,
+        // Has the current node handled parts, acks, all_acks from another node?
+        handled_parts: BTreeMap<usize, bool>,
+        handled_acks: BTreeMap<usize, bool>,
+        handled_all_acks: BTreeMap<usize, bool>,
+    }
+
+    impl MockNode {
+        pub fn new(num_nodes: usize) -> Vec<MockNode> {
+            let mut status: BTreeMap<usize, bool> = BTreeMap::new();
+            (0..num_nodes).for_each(|id| {
+                let _ = status.insert(id, false);
+            });
+            (0..num_nodes)
+                .map(|id| {
+                    // we have handled our parts/acks/all_acks by default
+                    let mut our_status = status.clone();
+                    our_status.insert(id, true);
+                    MockNode {
+                        id,
+                        handled_parts: our_status.clone(),
+                        handled_acks: our_status.clone(),
+                        handled_all_acks: our_status,
+                    }
+                })
+                .collect()
+        }
+
+        // return the node IDs that have not handled self's part; Also choose nodes which have already handled
+        // self's part with a probability of (num/den)
+        pub fn can_send_parts<R: RngCore>(
+            &self,
+            nodes: &[MockNode],
+            resend_probability: Option<(u32, u32)>,
+            rng: &mut R,
+        ) -> Vec<usize> {
+            nodes
+                .iter()
+                .filter_map(|node| {
+                    // if node has not handled self's part
+                    if !node.handled_parts[&self.id] {
+                        Some(node.id)
+                    } else {
+                        // resend to the node which has already handled self's part with the provided probability
+                        if let Some((num, den)) = resend_probability {
+                            if rng.gen_ratio(num, den) {
+                                Some(node.id)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                })
+                .collect()
+        }
+
+        pub fn can_send_acks<R: RngCore>(
+            &self,
+            nodes: &[MockNode],
+            resend_probability: Option<(u32, u32)>,
+            rng: &mut R,
+        ) -> Vec<usize> {
+            // if self has not handled the parts from other nodes, then it cant produce an ack
+            if !self.parts_done() {
+                return Vec::new();
+            }
+            // the other node should not have handled self's ack
+            nodes
+                .iter()
+                .filter_map(|node| {
+                    if !node.handled_acks[&self.id] {
+                        Some(node.id)
+                    } else {
+                        // resend to the node which has already handled self's ack with the provided probability
+                        if let Some((num, den)) = resend_probability {
+                            if rng.gen_ratio(num, den) {
+                                Some(node.id)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                })
+                .collect()
+        }
+
+        pub fn can_send_all_acks<R: RngCore>(
+            &self,
+            nodes: &[MockNode],
+            resend_probability: Option<(u32, u32)>,
+            rng: &mut R,
+        ) -> Vec<usize> {
+            // self should've handled all the acks/parts (except self's)
+            if !self.parts_done() {
+                return Vec::new();
+            }
+            if !self.acks_done() {
+                return Vec::new();
+            }
+            // the other node should not have handled self's all_ack
+            nodes
+                .iter()
+                .filter_map(|node| {
+                    if !node.handled_all_acks[&self.id] {
+                        Some(node.id)
+                    } else if let Some((num, den)) = resend_probability {
+                        if rng.gen_ratio(num, den) {
+                            Some(node.id)
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        }
+
+        // returns true if self has received/handled all the parts (except itself)
+        pub fn parts_done(&self) -> bool {
+            self.handled_parts
+                .iter()
+                .filter(|(&id, _)| id != self.id)
+                .all(|(_, &val)| val)
+        }
+
+        pub fn acks_done(&self) -> bool {
+            self.handled_acks
+                .iter()
+                .filter(|(&id, _)| id != self.id)
+                .all(|(_, &val)| val)
+        }
+
+        pub fn all_acks_done(&self) -> bool {
+            // check if current_node has completed the dkg round; i.e., it has handled all_acks from all other nodes
+            self.handled_all_acks
+                .iter()
+                .filter(|(&id, _)| id != self.id)
+                .all(|(_, &val)| val)
+        }
+
+        pub fn active_nodes(nodes: &[MockNode]) -> Vec<usize> {
+            // a node is active if any of the other node still requires votes from the current node
+            // filter out current node as we don't necessarily have to deal with our votes to move forward
+            let mut active_nodes = BTreeSet::new();
+            nodes.iter().for_each(|node| {
+                // check parts
+                node.handled_parts.iter().for_each(|(&id, &val)| {
+                    // if current node has not handled a part from another node (i.e. false), we need the other node
+                    if id != node.id && !val {
+                        active_nodes.insert(id);
+                    };
+                });
+
+                node.handled_acks.iter().for_each(|(&id, &val)| {
+                    if id != node.id && !val {
+                        active_nodes.insert(id);
+                    };
+                });
+
+                node.handled_all_acks.iter().for_each(|(&id, &val)| {
+                    if id != node.id && !val {
+                        active_nodes.insert(id);
+                    };
+                });
+            });
+            active_nodes.into_iter().collect()
+        }
+
+        // select a subset of node i's from the given list
+        pub fn sample_nodes<R: RngCore>(nodes: &Vec<usize>, rng: &mut R) -> Vec<usize> {
+            let sample_n_nodes = (rng.gen::<usize>() % nodes.len()) + 1;
+            nodes.iter().cloned().choose_multiple(rng, sample_n_nodes)
+        }
     }
 }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -80,6 +80,7 @@ impl DkgSignedVote {
 pub(crate) mod test_utils {
     use super::{DkgSignedVote, DkgVote};
 
+    #[allow(dead_code)]
     #[derive(Debug)]
     pub(crate) enum MockDkgVote {
         SinglePart,
@@ -87,12 +88,13 @@ pub(crate) mod test_utils {
         AllAcks,
     }
 
-    impl DkgSignedVote {
-        pub(crate) fn mock(&self) -> MockDkgVote {
-            match self.vote {
-                DkgVote::SinglePart(_) => MockDkgVote::SinglePart,
-                DkgVote::SingleAck(_) => MockDkgVote::SingleAck,
-                DkgVote::AllAcks(_) => MockDkgVote::AllAcks,
+    impl PartialEq<DkgSignedVote> for MockDkgVote {
+        fn eq(&self, other: &DkgSignedVote) -> bool {
+            match self {
+                MockDkgVote::SinglePart if matches!(other.vote, DkgVote::SinglePart(_)) => true,
+                MockDkgVote::SingleAck if matches!(other.vote, DkgVote::SingleAck(_)) => true,
+                MockDkgVote::AllAcks if matches!(other.vote, DkgVote::AllAcks(_)) => true,
+                _ => false,
             }
         }
     }

--- a/src/vote.rs
+++ b/src/vote.rs
@@ -75,3 +75,25 @@ impl DkgSignedVote {
         matches!(self.vote, DkgVote::AllAcks(_))
     }
 }
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use super::{DkgSignedVote, DkgVote};
+
+    #[derive(Debug)]
+    pub(crate) enum MockDkgVote {
+        SinglePart,
+        SingleAck,
+        AllAcks,
+    }
+
+    impl DkgSignedVote {
+        pub(crate) fn mock(&self) -> MockDkgVote {
+            match self.vote {
+                DkgVote::SinglePart(_) => MockDkgVote::SinglePart,
+                DkgVote::SingleAck(_) => MockDkgVote::SingleAck,
+                DkgVote::AllAcks(_) => MockDkgVote::AllAcks,
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Fuzz test
    - The `can_send_` functions encapsulates the current state of a node
    - Can send `Votes` to other nodes which have already handled the same vote
    - Can send out of order `Acks` / `AllAcks`, i.e., before the previous `Part` step / `Acks` step has been completed. 