### PR TITLE
chore: make DkgState cloneable

### DIFF
--- a/src/sdkg.rs
+++ b/src/sdkg.rs
@@ -169,7 +169,7 @@ impl Debug for Ack {
 }
 
 /// The information needed to track a single proposer's secret sharing process.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 struct ProposalState {
     /// The proposer's commitment.
     commit: BivarCommitment,
@@ -216,7 +216,7 @@ pub enum AckOutcome {
 /// A synchronous algorithm for dealerless distributed key generation.
 ///
 /// It requires that all nodes handle all messages in the exact same order.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SyncKeyGen<N> {
     /// Our node ID.
     our_id: N,

--- a/src/state.rs
+++ b/src/state.rs
@@ -16,6 +16,7 @@ use crate::vote::{DkgSignedVote, DkgVote, IdAck, IdPart, NodeId};
 
 /// State of the Dkg session, contains the sync keygen and currently known Parts and Acks
 /// Can handle votes coming from other participants
+#[derive(Clone)]
 pub struct DkgState {
     id: NodeId,
     secret_key: SecretKey,


### PR DESCRIPTION
This should allow us to move Dkg AE off the blocking thread in safenode